### PR TITLE
fix(workflows): move reusable workflows to correct directory, simplify starter workflow, update docs

### DIFF
--- a/.github/workflows/go_app_pull_requests.yml
+++ b/.github/workflows/go_app_pull_requests.yml
@@ -1,0 +1,127 @@
+name: Pull Request
+
+on:
+  workflow_call:
+    inputs:
+      GH_CI_USER:
+        description: 'User for GitHub auth'
+        required: true
+        type: string
+      GOPRIVATE:
+        description: 'GOPRIVATE env for go commands'
+        required: false
+        type: string
+    secrets:
+      GH_CI_PAT:
+        description: 'Token password for GitHub auth'
+        required: true
+
+env:
+  GOPRIVATE: ${{ inputs.GOPRIVATE }}
+
+jobs:
+  lint:
+    #
+    # runs golangci-lint
+    #
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout code to build.
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      # Setup Go in order to vendor dependencies in a later step.
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1'
+      # Use auth to get access to private Git repos for Go code dependencies.
+      - name: Configure git for private modules
+        env:
+          TOKEN: ${{ secrets.GH_CI_PAT }}
+          GITHUB_USERNAME: ${{ inputs.GH_CI_USER }}
+        run: git config --global url."https://${GITHUB_USERNAME}:${TOKEN}@github.com".insteadOf "https://github.com"
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: latest
+
+  test:
+    #
+    # ensure go standards and tests pass
+    #
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # List of go versions to test on.
+        go: ['^1.16', '^1.17', '^1']
+    steps:
+      # Checkout go code to test.
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      # Setup Go for each version in the matrix.
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      # Use auth to get access to private Git repos for Go code dependencies.
+      - name: Configure git for private modules
+        env:
+          TOKEN: ${{ secrets.GH_CI_PAT }}
+          GITHUB_USERNAME: ${{ inputs.GH_CI_USER }}
+        run: git config --global url."https://${GITHUB_USERNAME}:${TOKEN}@github.com".insteadOf "https://github.com"
+      # Vendor Go code for ever Go module.
+      - name: go mod vendor
+        run: find . -name vendor -prune -o -name go.mod -print | xargs -n1 dirname | xargs -n1 -I{} bash -c "pushd {}; go mod vendor"
+      # Go vet every Go module.
+      - name: go vet
+        run: find . -name vendor -prune -o -name go.mod -print | xargs -n1 dirname | xargs -n1 -I{} bash -c "pushd {}; go vet ./..."
+      # Run unit test for evet Go module.
+      - name: go test
+        run: find . -name vendor -prune -o -name go.mod -print | xargs -n1 dirname | xargs -n1 -I{} bash -c "pushd {}; go test -mod=vendor --race -v ./..."
+
+  docker-build:
+    #
+    # ensures the docker image will build without pushing to the registry
+    # uses the git sha for the most recent commit for the version
+    #
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout code to build.
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      # Setup Go in order to vendor dependencies in a later step.
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1'
+      # Use auth to get access to private Git repos for Go code dependencies.
+      - name: Configure git for private modules
+        env:
+          TOKEN: ${{ secrets.GH_CI_PAT }}
+          GITHUB_USERNAME: ${{ inputs.GH_CI_USER }}
+        run: git config --global url."https://${GITHUB_USERNAME}:${TOKEN}@github.com".insteadOf "https://github.com"
+      # Vendor Go code needed to build app.
+      - name: go mod vendor
+        run: go mod vendor
+      # Setup docker build arguments.
+      - name: Docker release meta
+        id: release
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ${{ github.repository }}
+          tags: |
+            type=sha
+      # Setup Docker builder to do build.
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      # Build the app.
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          tags: ${{ steps.release.outputs.tags }}

--- a/.github/workflows/go_app_release.yml
+++ b/.github/workflows/go_app_release.yml
@@ -1,0 +1,104 @@
+name: Release Docker Version
+
+on:
+  workflow_call:
+    inputs:
+      GH_CI_USER:
+        description: 'User for GitHub auth'
+        required: true
+        type: string
+      GOPRIVATE:
+        description: 'GOPRIVATE env for go commands'
+        required: false
+        type: string
+    secrets:
+      GH_CI_PAT:
+        description: 'Token password for GitHub auth'
+        required: true
+      # Container Registry arguments
+      CONTAINER_REGISTRY:
+        description: 'Container Registry address to which to publish (leave blank to not publish)'
+        required: false
+      CONTAINER_REGISTRY_JSON_KEY:
+        description: 'Key for publishing to Container Registry'
+        required: false
+
+env:
+  GOPRIVATE: ${{ inputs.GOPRIVATE }}
+
+jobs:
+  push:
+    #
+    # Build the Docker image artifact and deliver it.
+    #
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout code needed to build docker image.
+      - uses: actions/checkout@v2
+      # Setup Go in order to vendor dependencies in a later step.
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1'
+      # Use auth to get access to private Git repos for Go code dependencies.
+      - name: Configure git for private modules
+        env:
+          TOKEN: ${{ secrets.GH_CI_PAT }}
+          GITHUB_USERNAME: ${{ inputs.GH_CI_USER }}
+        run: git config --global url."https://${GITHUB_USERNAME}:${TOKEN}@github.com".insteadOf "https://github.com"
+      # Vendor Go code needed to build docker image.
+      - name: go mod vendor
+        run: go mod vendor
+      # Parse GitHub repository name for use in constructing docker image names.
+      - name: Parse Repo Name
+        id: parse_repo_name
+        run: |
+          echo ::set-output name=repo_name::"$( echo '${{ github.repository }}' | awk -F '/' '{print $2}' )"
+      # Make the docker fields for Container Registry if we're pushing to it.
+      - name: Construct Container Registry fields
+        env:
+          CONTAINER_REGISTRY: ${{ secrets.CONTAINER_REGISTRY }}
+        if: ${{ env.CONTAINER_REGISTRY }}
+        run: |
+          echo "CONTAINER_REGISTRY_IMAGE_NAME=${{ secrets.CONTAINER_REGISTRY }}/${{ steps.parse_repo_name.outputs.repo_name }}" >> $GITHUB_ENV
+      # Create docker image meta data. Docker tags include the Git tag itself and the sematic version parsing of that tag if possible.
+      - name: Docker release meta
+        id: release
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ${{ env.CONTAINER_REGISTRY_IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+      # Login to Container Registry if we're pushing to it.
+      - name: Login to Container Registry
+        env:
+          CONTAINER_REGISTRY_JSON_KEY: ${{ secrets.CONTAINER_REGISTRY_JSON_KEY }}
+        if: ${{ env.CONTAINER_REGISTRY_JSON_KEY }}
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.CONTAINER_REGISTRY }}
+          username: _json_key
+          password: ${{ secrets.CONTAINER_REGISTRY_JSON_KEY }}
+      # Setup QEMU needed to build arm64 images.
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+      # Setup Docker builder needed to build multi-architectural images.
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      # Build and push the image.
+      - name: Build and Push to Artifact Registry and Container Registry
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ steps.release.outputs.version }}
+          tags: ${{ steps.release.outputs.tags }}
+          labels: ${{ steps.release.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # .github
 
 This repository contains the default health files for the kochvalabs organization.  Documentation on how to setup this repository [here](https://help.github.com/en/articles/creating-a-default-community-health-file-for-your-organization#supported-file-types)
+
+## Workflows
+
+Reusable workflows must be in the `.github/workflows` directory.
+These can be used by other workflows.
+See the docs for [Reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow)
+for more information.
+
+Starter workflow for the organization can be created in the `workflow-templates` directory.
+These are able to be easily added to public repos or can be copied as a template for setting up workflows in other repositories.
+Starter workflows can use the reusable workflows to avoid duplication.
+See the docs for [Creating start workflows](https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization)
+for more information.

--- a/workflow-templates/go_app_pull_requests.properties.json
+++ b/workflow-templates/go_app_pull_requests.properties.json
@@ -1,5 +1,5 @@
 {
-    "name": "Pull Request",
+    "name": "Go App Pull Request",
     "description": "Pull Request starter workflow for Go apps.",
     "categories": [
         "Go"

--- a/workflow-templates/go_app_pull_requests.yml
+++ b/workflow-templates/go_app_pull_requests.yml
@@ -1,127 +1,13 @@
-name: Pull Request
+name: Pull Request Caller
 
 on:
-  workflow_call:
-    inputs:
-      GH_CI_USER:
-        description: 'User for GitHub auth'
-        required: true
-        type: string
-      GOPRIVATE:
-        description: 'GOPRIVATE env for go commands'
-        required: false
-        type: string
-    secrets:
-      GH_CI_PAT:
-        description: 'Token password for GitHub auth'
-        required: true
-
-env:
-  GOPRIVATE: ${{ inputs.GOPRIVATE }}
+  pull_request:
 
 jobs:
-  lint:
-    #
-    # runs golangci-lint
-    #
-    runs-on: ubuntu-latest
-    steps:
-      # Checkout code to build.
-      - name: Checkout repo
-        uses: actions/checkout@v2
-      # Setup Go in order to vendor dependencies in a later step.
-      - name: Setup Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '^1'
-      # Use auth to get access to private Git repos for Go code dependencies.
-      - name: Configure git for private modules
-        env:
-          TOKEN: ${{ secrets.GH_CI_PAT }}
-          GITHUB_USERNAME: ${{ inputs.GH_CI_USER }}
-        run: git config --global url."https://${GITHUB_USERNAME}:${TOKEN}@github.com".insteadOf "https://github.com"
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: latest
-
-  test:
-    #
-    # ensure go standards and tests pass
-    #
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # List of go versions to test on.
-        go: ['^1.16', '^1.17', '^1']
-    steps:
-      # Checkout go code to test.
-      - name: Checkout repo
-        uses: actions/checkout@v2
-      # Setup Go for each version in the matrix.
-      - name: Setup Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go }}
-      # Use auth to get access to private Git repos for Go code dependencies.
-      - name: Configure git for private modules
-        env:
-          TOKEN: ${{ secrets.GH_CI_PAT }}
-          GITHUB_USERNAME: ${{ inputs.GH_CI_USER }}
-        run: git config --global url."https://${GITHUB_USERNAME}:${TOKEN}@github.com".insteadOf "https://github.com"
-      # Vendor Go code for ever Go module.
-      - name: go mod vendor
-        run: find . -name vendor -prune -o -name go.mod -print | xargs -n1 dirname | xargs -n1 -I{} bash -c "pushd {}; go mod vendor"
-      # Go vet every Go module.
-      - name: go vet
-        run: find . -name vendor -prune -o -name go.mod -print | xargs -n1 dirname | xargs -n1 -I{} bash -c "pushd {}; go vet ./..."
-      # Run unit test for evet Go module.
-      - name: go test
-        run: find . -name vendor -prune -o -name go.mod -print | xargs -n1 dirname | xargs -n1 -I{} bash -c "pushd {}; go test -mod=vendor --race -v ./..."
-
-  docker-build:
-    #
-    # ensures the docker image will build without pushing to the registry
-    # uses the git sha for the most recent commit for the version
-    #
-    runs-on: ubuntu-latest
-    steps:
-      # Checkout code to build.
-      - name: Checkout repo
-        uses: actions/checkout@v2
-      # Setup Go in order to vendor dependencies in a later step.
-      - name: Setup Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '^1'
-      # Use auth to get access to private Git repos for Go code dependencies.
-      - name: Configure git for private modules
-        env:
-          TOKEN: ${{ secrets.GH_CI_PAT }}
-          GITHUB_USERNAME: ${{ inputs.GH_CI_USER }}
-        run: git config --global url."https://${GITHUB_USERNAME}:${TOKEN}@github.com".insteadOf "https://github.com"
-      # Vendor Go code needed to build app.
-      - name: go mod vendor
-        run: go mod vendor
-      # Setup docker build arguments.
-      - name: Docker release meta
-        id: release
-        uses: docker/metadata-action@v3
-        with:
-          images: |
-            ${{ github.repository }}
-          tags: |
-            type=sha
-      # Setup Docker builder to do build.
-      - name: Setup Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-      # Build the app.
-      - name: Build
-        uses: docker/build-push-action@v2
-        with:
-          push: false
-          context: .
-          file: Dockerfile
-          platforms: linux/amd64
-          tags: ${{ steps.release.outputs.tags }}
+  pull_request:
+    uses: kochavalabs/.github/.github/workflows/go_app_pull_requests.yml@v0.0.3
+    with:
+      GH_CI_USER: mazzaroth-dev
+      GOPRIVATE: "github.com/kochavalabs"
+    secrets:
+      GH_CI_PAT: ${{ secrets.GH_CI_PAT }}

--- a/workflow-templates/go_app_release.properties.json
+++ b/workflow-templates/go_app_release.properties.json
@@ -1,6 +1,6 @@
 {
-    "name": "Release Docker Version",
-    "description": "Release Docker Version starter workflow.",
+    "name": "Go App Release Docker Version",
+    "description": "Release Docker Version starter workflow for Go Apps.",
     "categories": [
         "Go"
     ],

--- a/workflow-templates/go_app_release.yml
+++ b/workflow-templates/go_app_release.yml
@@ -1,104 +1,17 @@
-name: Release Docker Version
+name: Release Docker Version Caller
 
 on:
-  workflow_call:
-    inputs:
-      GH_CI_USER:
-        description: 'User for GitHub auth'
-        required: true
-        type: string
-      GOPRIVATE:
-        description: 'GOPRIVATE env for go commands'
-        required: false
-        type: string
-    secrets:
-      GH_CI_PAT:
-        description: 'Token password for GitHub auth'
-        required: true
-      # Container Registry arguments
-      CONTAINER_REGISTRY:
-        description: 'Container Registry address to which to publish (leave blank to not publish)'
-        required: false
-      CONTAINER_REGISTRY_JSON_KEY:
-        description: 'Key for publishing to Container Registry'
-        required: false
-
-env:
-  GOPRIVATE: ${{ inputs.GOPRIVATE }}
+  release:
+    types:
+      - created
 
 jobs:
-  push:
-    #
-    # Build the Docker image artifact and deliver it.
-    #
-    runs-on: ubuntu-latest
-    steps:
-      # Checkout code needed to build docker image.
-      - uses: actions/checkout@v2
-      # Setup Go in order to vendor dependencies in a later step.
-      - name: Setup Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '^1'
-      # Use auth to get access to private Git repos for Go code dependencies.
-      - name: Configure git for private modules
-        env:
-          TOKEN: ${{ secrets.GH_CI_PAT }}
-          GITHUB_USERNAME: ${{ inputs.GH_CI_USER }}
-        run: git config --global url."https://${GITHUB_USERNAME}:${TOKEN}@github.com".insteadOf "https://github.com"
-      # Vendor Go code needed to build docker image.
-      - name: go mod vendor
-        run: go mod vendor
-      # Parse GitHub repository name for use in constructing docker image names.
-      - name: Parse Repo Name
-        id: parse_repo_name
-        run: |
-          echo ::set-output name=repo_name::"$( echo '${{ github.repository }}' | awk -F '/' '{print $2}' )"
-      # Make the docker fields for Container Registry if we're pushing to it.
-      - name: Construct Container Registry fields
-        env:
-          CONTAINER_REGISTRY: ${{ secrets.CONTAINER_REGISTRY }}
-        if: ${{ env.CONTAINER_REGISTRY }}
-        run: |
-          echo "CONTAINER_REGISTRY_IMAGE_NAME=${{ secrets.CONTAINER_REGISTRY }}/${{ steps.parse_repo_name.outputs.repo_name }}" >> $GITHUB_ENV
-      # Create docker image meta data. Docker tags include the Git tag itself and the sematic version parsing of that tag if possible.
-      - name: Docker release meta
-        id: release
-        uses: docker/metadata-action@v3
-        with:
-          images: |
-            ${{ env.CONTAINER_REGISTRY_IMAGE_NAME }}
-          flavor: |
-            latest=false
-          tags: |
-            type=ref,event=tag
-            type=semver,pattern={{version}}
-      # Login to Container Registry if we're pushing to it.
-      - name: Login to Container Registry
-        env:
-          CONTAINER_REGISTRY_JSON_KEY: ${{ secrets.CONTAINER_REGISTRY_JSON_KEY }}
-        if: ${{ env.CONTAINER_REGISTRY_JSON_KEY }}
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ secrets.CONTAINER_REGISTRY }}
-          username: _json_key
-          password: ${{ secrets.CONTAINER_REGISTRY_JSON_KEY }}
-      # Setup QEMU needed to build arm64 images.
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v1
-      # Setup Docker builder needed to build multi-architectural images.
-      - name: Setup Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-      # Build and push the image.
-      - name: Build and Push to Artifact Registry and Container Registry
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          context: .
-          file: Dockerfile
-          platforms: linux/amd64,linux/arm64
-          build-args: |
-            VERSION=${{ steps.release.outputs.version }}
-          tags: ${{ steps.release.outputs.tags }}
-          labels: ${{ steps.release.outputs.labels }}
+  release:
+    uses: kochavalabs/.github/.github/workflows/go_app_release.yml@v0.0.3
+    with:
+      GH_CI_USER: mazzaroth-dev
+      GOPRIVATE: "github.com/kochavalabs"
+    secrets:
+      GH_CI_PAT: ${{ secrets.GH_CI_PAT }}
+      CONTAINER_REGISTRY: "gcr.io/kl-i-cicd-kwpj"
+      CONTAINER_REGISTRY_JSON_KEY: ${{ secrets.GH_IMG_PUBLISH_JSON_KEY }}


### PR DESCRIPTION
# Description

As described [here](https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow) reusable workflows must be in the `.github/workflows` directory.  This is not the same as starter workflows which are copied from the `.github/workflow-templates` directory.  

To prevent duplication on starter workflows they can use the reusable workflows as described in the note [here](https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow).

This update moves the existing reusable workflows to the correct location and adds base starter workflows that contain minimal setup.

Added additional details about the workflows to the README
