### PR TITLE
fix(workflows): remove arm64 target from go app release

### DIFF
--- a/.github/workflows/go_app_release.yml
+++ b/.github/workflows/go_app_release.yml
@@ -83,9 +83,6 @@ jobs:
           registry: ${{ secrets.CONTAINER_REGISTRY }}
           username: _json_key
           password: ${{ secrets.CONTAINER_REGISTRY_JSON_KEY }}
-      # Setup QEMU needed to build arm64 images.
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v1
       # Setup Docker builder needed to build multi-architectural images.
       - name: Setup Docker Buildx
         id: buildx
@@ -97,7 +94,7 @@ jobs:
           push: true
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           build-args: |
             VERSION=${{ steps.release.outputs.version }}
           tags: ${{ steps.release.outputs.tags }}


### PR DESCRIPTION
# Description

Removing the arm64 target for the go app release docker build.  This is not currently needed.  
Also, the go app pull request test does not currently build for this target which would not catch potential issues building for that target on release.